### PR TITLE
chore: align version to 0.1.5

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@btc-stamps/tx-builder",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A comprehensive Bitcoin transaction builder library with support for Bitcoin Stamps, SRC-20 tokens, UTXO selection algorithms, and advanced fee optimization",
   "exports": {
     ".": "./src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btc-stamps/tx-builder",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Transaction builder for Bitcoin Stamps and SRC-20 tokens with advanced UTXO selection",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Align package versions to match npm release v0.1.5 before running next release workflow