### PR TITLE
chore: release v0.1.7

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@btc-stamps/tx-builder",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "A comprehensive Bitcoin transaction builder library with support for Bitcoin Stamps, SRC-20 tokens, UTXO selection algorithms, and advanced fee optimization",
   "exports": {
     ".": "./src/index.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@btc-stamps/tx-builder",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@btc-stamps/tx-builder",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btc-stamps/tx-builder",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Transaction builder for Bitcoin Stamps and SRC-20 tokens with advanced UTXO selection",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Automated version bump to v0.1.7

This PR was created after the release workflow successfully published to npm and JSR.

## Published to:
- ✅ npm: https://www.npmjs.com/package/@btc-stamps/tx-builder/v/0.1.7
- ✅ JSR: https://jsr.io/@btc-stamps/tx-builder@0.1.7

## Changes:
- Updated package.json version to 0.1.7
- Updated deno.json version to 0.1.7  
- Updated package-lock.json

Please merge this PR to keep the repository in sync with published versions.